### PR TITLE
refactored script to initialize db

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,4 @@
 1. Download [Postgres](https://www.postgresql.org/)
 2. Create database named 'team-bluejay' using a SQL client of your choice. [Instructions for database creation](https://www.guru99.com/postgresql-create-database.html) using pgAdmin which is automatically downloaded with Postgres. (Instructions are halfway down the link page)
 3. Update password variable in `app.py` to match your SQL password
-4. Create database within command line terminal using 
-```sh
-pipenv run createdb
-```
+4. Initialize database tables with `pipenv run init_db`

--- a/server/Pipfile
+++ b/server/Pipfile
@@ -19,4 +19,4 @@ flask-jwt-extended = "*"
 python_version = "3.8"
 
 [scripts]
-createdb = "./createdb.py"
+init_db = "init_db.py"

--- a/server/createdb.py
+++ b/server/createdb.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-
-from app import create_app
-app = create_app()
-app.app_context().push()
-from app import db
-db.create_all()
-print("just ran createdb.py")
-exit()

--- a/server/init_db.py
+++ b/server/init_db.py
@@ -1,0 +1,6 @@
+from app import create_app, db
+app = create_app()
+app.app_context().push()
+db.create_all()
+print("Initialized database with tables")
+exit()


### PR DESCRIPTION
Just a refactor of existing script to initialize db

@giftofgrub check that this script works on a mac.  i changed  `create_db = "./create_db.py"`  to `init_db = "init_db.py"`  on Windows the `./` created problems for me.  Make sure removing the `./` still works on a mac.