### PR TITLE
BE: requests to meal items also return chef info.

### DIFF
--- a/server/models/MealItem.py
+++ b/server/models/MealItem.py
@@ -17,7 +17,6 @@ class MealItem(db.Model):
     description = db.Column(db.Text, nullable=True)
     ingredients = db.Column(db.String(128), nullable=True)
     required_items = db.Column(db.String(128), nullable=True)
-    # to access chef info from a meal item -DONE
     user = db.relationship("User", back_populates="mealItems")
 
     def __init__(self, userId, name, price, servings, description="", ingredients="", required_items=""):

--- a/server/models/MealItem.py
+++ b/server/models/MealItem.py
@@ -17,8 +17,8 @@ class MealItem(db.Model):
     description = db.Column(db.Text, nullable=True)
     ingredients = db.Column(db.String(128), nullable=True)
     required_items = db.Column(db.String(128), nullable=True)
-    # to access chef info from a meal item
-    user = db.relationship("User")
+    # to access chef info from a meal item -DONE
+    user = db.relationship("User", back_populates="mealItems")
 
     def __init__(self, userId, name, price, servings, description="", ingredients="", required_items=""):
         self.userId = userId
@@ -50,3 +50,4 @@ class MealItemSchema(Schema):
     description = fields.Str()
     ingredients = fields.Str()
     required_items = fields.Str()
+    user = fields.Nested("UserSchema", exclude=("mealItems",))

--- a/server/models/User.py
+++ b/server/models/User.py
@@ -21,7 +21,7 @@ class User(db.Model):
     aboutMe = db.Column(db.Text)
     chefDescription = db.Column(db.Text)
 
-    mealItems = db.relationship("MealItem")
+    mealItems = db.relationship("MealItem", back_populates="user")
     # Todo: this method of initializing with default values feels very sloppy and a better way to do it probably exists
 
     def __init__(self, name, email, password, **kwargs):


### PR DESCRIPTION
 I updated Gabriel's branch `in-chef-profile` so that requests to chefs return meal items info and likewise requests to meal items return chef info. 

To test: create users and meals using Postman.  Returned user and meal objects in postman should be like below images.

USER INFO WITH MEALS
![userInfo_with meals](https://user-images.githubusercontent.com/29524485/83768277-91ad4b00-a64c-11ea-809c-aeff7943a84a.png)

MEAL INFO WITH USERS
![mealItem with userInfo](https://user-images.githubusercontent.com/29524485/83768478-d5a05000-a64c-11ea-978f-735c88044e94.png)
